### PR TITLE
refactor: Commit to gh-pages directly instead of using peaceiris/actions-gh-pages

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     tags:
-    - '*'
+      - "*"
 
 jobs:
   build:
@@ -21,8 +21,17 @@ jobs:
       - name: fix permissions
         run: |
           sudo chown -R $USER docs
+      - name: Configure Git
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --global url."https://${GH_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
       - name: Update GH pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+        run: |
+          git fetch origin gh-pages
+          git checkout -B gh-pages origin/gh-pages || git checkout --orphan gh-pages
+          cp -r ./docs/* .
+          git add .
+          git commit -m "Update documentation for $GITHUB_REF" || echo "No changes to commit"


### PR DESCRIPTION


## Description

Part of https://github.com/kubewarden/kubewarden-controller/issues/1097

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Untested, the current GHA run fails on obtaining the image `swiftdoc/swift-doc`:
https://github.com/viccuad/policy-sdk-swift/actions/runs/15042388843/job/42276958951

The swift-doc repository is archived. See:
https://github.com/kubewarden/kubewarden-controller/issues/1090
https://github.com/SwiftDocOrg/swift-doc

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
